### PR TITLE
Add Homebrew tap and release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build
+        run: swift build -c release
+
+      - name: Bundle app
+        run: |
+          mkdir -p Fuso.app/Contents/MacOS
+          mkdir -p Fuso.app/Contents/Resources
+          cp .build/release/Fuso Fuso.app/Contents/MacOS/Fuso
+          cp Sources/Info.plist Fuso.app/Contents/Info.plist
+          zip -r Fuso.zip Fuso.app
+
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create ${{ github.ref_name }} Fuso.zip \
+            --title "${{ github.ref_name }}" \
+            --generate-notes

--- a/README.md
+++ b/README.md
@@ -8,13 +8,19 @@ Named after *fuso horario*, Portuguese for timezone.
 
 ## Install
 
+### Homebrew
+
+```bash
+brew tap zaptech-dev/tap
+brew install --cask fuso
+```
+
+### From source
+
 ```bash
 git clone https://github.com/zaptech-dev/fuso.git
 cd fuso
-swift build -c release
-mkdir -p Fuso.app/Contents/MacOS
-cp .build/release/Fuso Fuso.app/Contents/MacOS/Fuso
-cp -R Fuso.app /Applications/
+./install.sh
 open /Applications/Fuso.app
 ```
 

--- a/Sources/Info.plist
+++ b/Sources/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleName</key>
+    <string>Fuso</string>
+    <key>CFBundleIdentifier</key>
+    <string>dev.zaptech.fuso</string>
+    <key>CFBundleVersion</key>
+    <string>1.0.0</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0.0</string>
+    <key>CFBundleExecutable</key>
+    <string>Fuso</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>LSMinimumSystemVersion</key>
+    <string>13.0</string>
+    <key>LSUIElement</key>
+    <true/>
+    <key>NSHighResolutionCapable</key>
+    <true/>
+</dict>
+</plist>

--- a/install.sh
+++ b/install.sh
@@ -10,6 +10,7 @@ echo "Creating app bundle..."
 mkdir -p Fuso.app/Contents/MacOS
 mkdir -p Fuso.app/Contents/Resources
 cp .build/release/Fuso Fuso.app/Contents/MacOS/Fuso
+cp Sources/Info.plist Fuso.app/Contents/Info.plist
 
 echo "Installing to /Applications..."
 cp -R Fuso.app /Applications/Fuso.app


### PR DESCRIPTION
Adds `brew tap zaptech-dev/tap && brew install --cask fuso` as an install path.

Includes a GitHub Actions workflow that builds and publishes a release on tag push, a proper Info.plist for the app bundle, and updated README.

Closes #1